### PR TITLE
Fix batch deposit script for different BLS withdrawal credentials

### DIFF
--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -4,13 +4,16 @@ RPC_URL=https://dai.poa.network
 GAS_PRICE=1000000000
 
 # number of deposits in one transaction, should be in range [1, 128]
+# NOTE: put 1 here if withdrawal credentials were generated with the BLS12-381 keys
 BATCH_SIZE=128
 # total number of deposits to read from file
 N=256
 # index of the first deposit to read from file
 OFFSET=0
 
-# address of the wrapped SBC token
-TOKEN_ADDRESS=0x0000000000000000000000000000000000000000
-# address of the SBC deposit contract
-DEPOSIT_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000
+# address of the wrapped GBC token
+TOKEN_ADDRESS=0x722fc4DAABFEaff81b97894fC623f91814a1BF68
+# address of the GBC deposit contract
+DEPOSIT_CONTRACT_ADDRESS=0x0B98057eA310F4d31F2a452B414647007d1645d9
+# block where the deposit contract was deployed at
+START_BLOCK_NUMBER=19469077


### PR DESCRIPTION
We don't need to check that all deposits have the same withdrawal credentials, instead, we can only check that all deposits from the same batch have the same credentials. This implies that for a batch size of 1, all withdrawal credentials might be different, which is usually the case with the BLS credentials derived from validator mnemonic.