### PR TITLE
Estimate gas for withdrawals

### DIFF
--- a/contracts/test/ERC20TestMintable.sol
+++ b/contracts/test/ERC20TestMintable.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: CC0-1.0
+
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Pausable.sol";
+import "../utils/Claimable.sol";
+import "../utils/PausableEIP1967Admin.sol";
+import "../interfaces/IERC677.sol";
+import "../interfaces/IERC677Receiver.sol";
+
+/**
+ * @title Test ERC20 with mintable permissions to admin
+ */
+contract ERC20TestMintable is IERC677, ERC20Pausable, PausableEIP1967Admin, Claimable {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    /**
+     * @dev UNSAFE anyone can mint
+     */
+    function mint(address _to, uint256 _amount) external {
+        _mint(_to, _amount);
+    }
+
+    /**
+     * @dev Implements the ERC677 transferAndCall standard.
+     * Executes a regular transfer, but calls the receiver's function to handle them in the same transaction.
+     * @param _to tokens receiver.
+     * @param _amount amount of sent tokens.
+     * @param _data extra data to pass to the callback function.
+     */
+    function transferAndCall(
+        address _to,
+        uint256 _amount,
+        bytes calldata _data
+    ) external override {
+        address sender = _msgSender();
+        _transfer(sender, _to, _amount);
+        require(IERC677Receiver(_to).onTokenTransfer(sender, _amount, _data), "SBCToken: ERC677 callback failed");
+    }
+}

--- a/test/estimateWithdrawalGas.js
+++ b/test/estimateWithdrawalGas.js
@@ -1,0 +1,117 @@
+require('chai').use(require('chai-as-promised')).should()
+const {expect} = require("chai")
+
+const SBCDepositContractProxy = artifacts.require('SBCDepositContractProxy.sol')
+const SBCDepositContract = artifacts.require('SBCDepositContract.sol')
+const SBCWrapperProxy = artifacts.require('SBCWrapperProxy.sol')
+const SBCWrapper = artifacts.require('SBCWrapper.sol')
+const SBCTokenProxy = artifacts.require('SBCTokenProxy.sol')
+const SBCToken = artifacts.require('SBCToken.sol')
+const ERC20TestMintable = artifacts.require('ERC20TestMintable.sol')
+
+
+contract('estimate withdrawal gas', (accounts) => {
+  const toMintWei = BigInt(2) ** BigInt(200)
+  const admin = accounts[0];
+  const withdrawalAmount = '0x0000000773594000' // 32 * 10^9
+  const withdrawalCountUpTo = 64; // more than 64 tx reverts
+
+  let tokenProxy
+  let token
+  let wrapperProxy
+  let wrapper
+  let contractImplementation
+  let contractProxy
+  let contract
+  let stake
+  beforeEach(async () => {
+    stake = await ERC20TestMintable.new("test GNO", "tGNO")
+    tokenProxy = await SBCTokenProxy.new(admin, 'SBC Token', 'SBCT')
+    token = await SBCToken.at(tokenProxy.address)
+    contractProxy = await SBCDepositContractProxy.new(admin, token.address, stake.address, stake.address)
+    contract = await SBCDepositContract.at(contractProxy.address)
+    wrapperProxy = await SBCWrapperProxy.new(admin, token.address, contract.address)
+    wrapper = await SBCWrapper.at(wrapperProxy.address)
+    await token.setMinter(wrapper.address)
+
+    contractImplementation = await SBCDepositContract.new(token.address, wrapper.address, stake.address)
+    await contractProxy.upgradeTo(contractImplementation.address, { from: admin })
+
+    await wrapper.enableToken(stake.address, web3.utils.toWei('32'))
+    await stake.mint(admin, toMintWei)
+    await stake.approve(wrapper.address, toMintWei)
+  })
+
+  it('estimate gas cost of successful withdrawals', async () => {
+    await contract.setOnWithdrawalsUnwrapToGNOByDefault(true)
+    await fundDepositContract(BigInt(2) ** BigInt(190), "0x")
+
+    for (let n = 1; n <= withdrawalCountUpTo; n = n * 2) {
+      const {amounts, addresses} = populateWithdrawals(n);
+      const tx = await contract.executeSystemWithdrawals(0, amounts, addresses)
+      expect(getLogEventNames(tx)).deep.equals(fill(n, 'WithdrawalExecuted'))
+      console.log(formatGasLog("success withdrawal", n, tx))
+    }
+  })
+
+  it('estimate gas cost of failed withdrawals', async () => {
+    await contract.setOnWithdrawalsUnwrapToGNOByDefault(true)
+
+    for (let n = 1; n <= withdrawalCountUpTo; n = n * 2) {
+      const {amounts, addresses} = populateWithdrawals(n);
+      const tx = await contract.executeSystemWithdrawals(0, amounts, addresses)
+      // Failed withdrawal emit 1 WithdrawalFailed log per withdrawal
+      expect(getLogEventNames(tx)).deep.equals(fill(n, 'WithdrawalFailed'))
+      console.log(formatGasLog("failed withdrawal", n, tx))
+    }
+
+    for (let n = 1; n <= withdrawalCountUpTo; n = n * 2) {
+      const tx = await contract.executeSystemWithdrawals(n, [], [])
+      // Failed retries do not emit logs
+      expect(getLogEventNames(tx)).deep.equals([])
+      console.log(formatGasLog("retry fail withdrawal", n, tx))
+    }
+
+    await fundDepositContract(BigInt(2) ** BigInt(190), "0x")
+
+    for (let n = 1; n <= withdrawalCountUpTo; n = n * 2) {
+      const {amounts, addresses} = populateWithdrawals(n);
+      const tx = await contract.executeSystemWithdrawals(0, amounts, addresses)
+      expect(getLogEventNames(tx)).deep.equals(fill(n, 'WithdrawalExecuted'))
+      console.log(formatGasLog("retry success withdrawal", n, tx))
+    }
+  })
+
+  async function fundDepositContract(amount) {
+    await wrapper.swap(stake.address, amount, "0x")
+    await token.transfer(contract.address, amount)
+  }
+
+  function populateWithdrawals(n) {
+    const amounts = [] 
+    const addresses = []
+    for (let i = 0; i < n; i++) {
+      amounts.push(withdrawalAmount)
+      // Prepending with ff to not transfer to zero address
+      addresses.push("0xff" + String(i).padStart(40 - 2, "0"))
+    }
+    return {amounts, addresses}
+  }
+
+  function formatGasLog(msg, n, tx) {
+    return `${msg} count: ${n} gasUsed: ${tx.receipt.gasUsed} gas/w: ${Math.round(tx.receipt.gasUsed / n)}`
+  }
+})
+
+
+function getLogEventNames(tx) {
+  return tx.logs.map(log => log.event)
+}
+
+function fill(n, value) {
+  const arr = []
+  for (let i = 0; i < n; i++) {
+    arr.push(value)
+  }
+  return arr
+}


### PR DESCRIPTION
Results with current commit and `setOnWithdrawalsUnwrapToGNOByDefault == true`

| item | count | gasUsed | gas / w |
| ---- | ----- | ------- | ------- |
| success withdrawal | 1 | 106440 | 106440 |
| success withdrawal | 2 | 155905 | 77953 |
| success withdrawal | 4 | 269835 | 67459 |
| success withdrawal | 8 | 497707 | 62213 |
| success withdrawal | 16 | 953429 | 59589 |
| success withdrawal | 32 | 1864876 | 58277 |
| success withdrawal | 64 | 3687782 | 57622 |
| failed withdrawal | 1 | 112103 | 112103 |
| failed withdrawal | 2 | 160640 | 80320 |
| failed withdrawal | 4 | 287714 | 71929 |
| failed withdrawal | 8 | 541875 | 67734 |
| failed withdrawal | 16 | 1050177 | 65636 |
| failed withdrawal | 32 | 2066790 | 64587 |
| failed withdrawal | 64 | 4100056 | 64063 |
| retry fail withdrawal | 1 | 50353 | 50353 |
| retry fail withdrawal | 2 | 50353 | 25177 |
| retry fail withdrawal | 4 | 50353 | 12588 |
| retry fail withdrawal | 8 | 50353 | 6294 |
| retry fail withdrawal | 16 | 50353 | 3147 |
| retry fail withdrawal | 32 | 50353 | 1574 |
| retry fail withdrawal | 64 | 50353 | 787 |
| retry success withdrawal | 1 | 106440 | 106440 |
| retry success withdrawal | 2 | 155905 | 77953 |
| retry success withdrawal | 4 | 269835 | 67459 |
| retry success withdrawal | 8 | 497707 | 62213 |
| retry success withdrawal | 16 | 953429 | 59589 |
| retry success withdrawal | 32 | 1864876 | 58277 |
| retry success withdrawal | 64 | 3687782 | 57622 |
