### PR TITLE
Skip bad withdrawals

### DIFF
--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -299,6 +299,17 @@ contract SBCDepositContract is
         bool _unwrapToGNO,
         uint256 gasLimit
     ) internal returns (bool success) {
+        // Skip withdrawal that burns tokens to avoid a revert condition
+        // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/dad73159df3d3053c72b5e430fa8164330f18068/contracts/token/ERC20/ERC20.sol#L278
+        if (_receiver == address(0)) {
+            return true;
+        }
+
+        // Skip withdrawal for 0 tokens
+        if (_amount == 0) {
+            return true;
+        }
+
         try this.processWithdrawalInternal{gas: gasLimit}(_amount, _receiver, _unwrapToGNO) {
             return true;
         } catch {

--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -305,11 +305,6 @@ contract SBCDepositContract is
             return true;
         }
 
-        // Skip withdrawal for 0 tokens
-        if (_amount == 0) {
-            return true;
-        }
-
         try this.processWithdrawalInternal{gas: gasLimit}(_amount, _receiver, _unwrapToGNO) {
             return true;
         } catch {


### PR DESCRIPTION
Skip bad withdrawals to ensure that a revert can only be triggered by insolvency of stake tokens
- Ref https://github.com/gnosischain/deposit-contract/pull/25