### PR TITLE
Test bad withdrawals

### DIFF
--- a/test/deposit.js
+++ b/test/deposit.js
@@ -46,6 +46,7 @@ function joinHex(args) {
 
 const sixteenEther = web3.utils.toWei('16')
 const thirtyTwoEther = web3.utils.toWei('32')
+const zeroEther = web3.utils.toWei('0')
 const zeroAddress = "0x0000000000000000000000000000000000000000"
 
 contract('SBCDepositContractProxy', (accounts) => {
@@ -403,7 +404,7 @@ contract('SBCDepositContractProxy', (accounts) => {
     expect(mGNOBalanceAfterWithdrawal).to.be.equal(web3.utils.toWei('0'))
   })
 
-  it('should correctly withdraw mGO to zero address', async () => {
+  it('should correctly drop a withdraw to zero address', async () => {
     const amounts = ['0x0000000773594000'] // 32 * 10^9
     const addresses = [zeroAddress]
 
@@ -412,10 +413,10 @@ contract('SBCDepositContractProxy', (accounts) => {
 
     assertSuccessfulWithdrawal(await contract.executeSystemWithdrawals(0, amounts, addresses))
     const mGNOBalanceAfterFirstWithdrawal = (await token.balanceOf(zeroAddress)).toString()
-    expect(mGNOBalanceAfterFirstWithdrawal).to.be.equal(thirtyTwoEther)
+    expect(mGNOBalanceAfterFirstWithdrawal).to.be.equal(zeroEther)
   })
 
-  it('should correctly withdraw GNO to zero address', async () => {
+  it('should correctly drop awithdraw GNO to zero address', async () => {
     const amounts = ['0x0000000773594000'] // 32 * 10^9
     const addresses = [zeroAddress]
 
@@ -426,7 +427,7 @@ contract('SBCDepositContractProxy', (accounts) => {
 
     assertSuccessfulWithdrawal(await contract.executeSystemWithdrawals(0, amounts, addresses))
     const mGNOBalanceAfterFirstWithdrawal = (await stake.balanceOf(zeroAddress)).toString()
-    expect(mGNOBalanceAfterFirstWithdrawal).to.be.equal(web3.utils.toWei('1'))
+    expect(mGNOBalanceAfterFirstWithdrawal).to.be.equal(zeroEther)
   })
 
   it('should claim tokens', async () => {

--- a/test/deposit.js
+++ b/test/deposit.js
@@ -455,7 +455,7 @@ contract('SBCDepositContractProxy', (accounts) => {
 })
 
 function assertSuccessfulWithdrawal(tx) {
-  const firstEvent = tx.logs[0];
-  if (!firstEvent) throw Error('tx has no events')
-  expect(firstEvent.event).equal('WithdrawalExecuted')
+  const withdrawEvent = tx.logs.find(log => log.event.startsWith("Withdrawal"))
+  if (!withdrawEvent) throw Error('tx has no Withdraw* events')
+  expect(withdrawEvent.event).equal('WithdrawalExecuted')
 }

--- a/test/deposit.js
+++ b/test/deposit.js
@@ -384,7 +384,7 @@ contract('SBCDepositContractProxy', (accounts) => {
     // simple withdrawal
     await token.transfer(contract.address, thirtyTwoEther)
 
-    await contract.executeSystemWithdrawals(0, amounts, addresses)
+    assertSuccessfulWithdrawal(await contract.executeSystemWithdrawals(0, amounts, addresses))
     const mGNOBalanceAfterWithdrawal = (await token.balanceOf(accounts[1])).toString()
     expect(mGNOBalanceAfterWithdrawal).to.be.equal(web3.utils.toWei('0'))
   })
@@ -398,7 +398,7 @@ contract('SBCDepositContractProxy', (accounts) => {
     // simple withdrawal
     await token.transfer(contract.address, thirtyTwoEther)
 
-    await contract.executeSystemWithdrawals(0, amounts, addresses)
+    assertSuccessfulWithdrawal(await contract.executeSystemWithdrawals(0, amounts, addresses))
     const mGNOBalanceAfterWithdrawal = (await stake.balanceOf(accounts[1])).toString()
     expect(mGNOBalanceAfterWithdrawal).to.be.equal(web3.utils.toWei('0'))
   })
@@ -410,7 +410,7 @@ contract('SBCDepositContractProxy', (accounts) => {
     // simple withdrawal
     await token.transfer(contract.address, thirtyTwoEther)
 
-    await contract.executeSystemWithdrawals(0, amounts, addresses)
+    assertSuccessfulWithdrawal(await contract.executeSystemWithdrawals(0, amounts, addresses))
     const mGNOBalanceAfterFirstWithdrawal = (await token.balanceOf(zeroAddress)).toString()
     expect(mGNOBalanceAfterFirstWithdrawal).to.be.equal(thirtyTwoEther)
   })
@@ -424,7 +424,7 @@ contract('SBCDepositContractProxy', (accounts) => {
     // simple withdrawal
     await token.transfer(contract.address, thirtyTwoEther)
 
-    await contract.executeSystemWithdrawals(0, amounts, addresses)
+    assertSuccessfulWithdrawal(await contract.executeSystemWithdrawals(0, amounts, addresses))
     const mGNOBalanceAfterFirstWithdrawal = (await stake.balanceOf(zeroAddress)).toString()
     expect(mGNOBalanceAfterFirstWithdrawal).to.be.equal(web3.utils.toWei('1'))
   })
@@ -453,3 +453,9 @@ contract('SBCDepositContractProxy', (accounts) => {
     expect(await contractProxy.admin()).to.be.equal(accounts[2])
   })
 })
+
+function assertSuccessfulWithdrawal(tx) {
+  const firstEvent = tx.logs[0];
+  if (!firstEvent) throw Error('tx has no events')
+  expect(firstEvent.event).equal('WithdrawalExecuted')
+}


### PR DESCRIPTION
@Barichek this PR seems to prove that withdrawals to zero address break. Please take a look

Revert is caused because of OpenZepelin's ERC20 implementation of _transfer https://github.com/OpenZeppelin/openzeppelin-contracts/blob/f8e3c375d19bd12f54222109dd0801c0e0b60dd2/contracts/token/ERC20/ERC20.sol#L224

```diff
    function _transfer(address from, address to, uint256 amount) internal virtual {
         require(from != address(0), "ERC20: transfer from the zero address");
+        require(to != address(0), "ERC20: transfer to the zero address");
```