### PR TITLE
Remove same withdraw credentials check

### DIFF
--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -144,18 +144,6 @@ contract SBCDepositContract is
         uint256 deposit_amount = stake_amount / 1 gwei;
         require(deposit_amount <= type(uint64).max, "DepositContract: deposit value too high");
 
-        // Don't allow to use different withdrawal credentials for subsequent deposits
-        bytes32 saved_wc = validator_withdrawal_credentials[pubkey];
-        bytes32 wc;
-        assembly {
-            wc := mload(add(withdrawal_credentials, 32))
-        }
-        if (saved_wc == bytes32(0)) {
-            validator_withdrawal_credentials[pubkey] = wc;
-        } else {
-            require(saved_wc == wc, "DepositContract: invalid withdrawal_credentials");
-        }
-
         // Emit `DepositEvent` log
         bytes memory amount = to_little_endian_64(uint64(deposit_amount));
         emit DepositEvent(

--- a/test/deposit.js
+++ b/test/deposit.js
@@ -181,8 +181,8 @@ contract('SBCDepositContractProxy', (accounts) => {
     expect((await stake.balanceOf(contract.address)).toString()).to.be.equal('1000000000000000000')
   })
 
-  it('should not accept other withdrawal credentials', async () => {
-    await stake.approve(contract.address, '3000000000000000000')
+  it('should accept other withdrawal credentials', async () => {
+    await stake.approve(contract.address, '6000000000000000000')
     for (let i = 0; i < 2; i++) {
       await contract.deposit(
         depositWC1.pubkey,
@@ -197,7 +197,7 @@ contract('SBCDepositContractProxy', (accounts) => {
         depositWC2.signature,
         depositWC2.deposit_data_root,
         depositWC2.value
-      ).should.be.rejected
+      )
     }
   })
 


### PR DESCRIPTION
Found by Adam Kolar

> If there is some implicit assumption in the system that all valid deposits share the same withdrawal_credentials , this is not necessarily true, since it's possible to submit a deposit with withdrawal_credentials == bytes32(0) which will leave validator_withdrawal_credentials[pubkey] updateable in the next deposit.

> So the biggest issue with the validator_withdrawal_credentials mapping seems to be that it allows anybody to burn a unused public key even with a deposit that has an invalid signature, you can imagine a deposit transaction being frontrun and blocked by this for example. The key should be disposable in most cases, but maybe there are some situations where this might cause problems. 

The beacon chain spec can handle deposits with different withdraw credentials. Only the first valid deposit can set withdraw credentials. Since a BLS verification check is done before, only the owner of that key can lock the pubkey to withdraw credentials. However this smart contract guard **locks** the pubkey **without** checking the signature, which opens the attack described above.