### PR TITLE
Add script to generate devnet genesis bytecode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,6 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        task: [lint, test]
     steps:
       - uses: actions/setup-node@v2
         with:
@@ -23,4 +19,7 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn
         if: ${{ !steps.yarn-cache.outputs.cache-hit }}
-      - run: yarn ${{ matrix.task }}
+      - run: yarn lint
+      - run: yarn test
+      - run: ADMIN=0xba61bac431387687512367672613571625671547 npm run compute-genesis-bytecode
+

--- a/contracts/test/SBCInit.sol
+++ b/contracts/test/SBCInit.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: CC0-1.0
+
+pragma solidity ^0.8.9;
+
+import "../SBCDepositContractProxy.sol";
+import "../SBCToken.sol";
+import "../SBCTokenProxy.sol";
+import "../SBCWrapper.sol";
+import "../SBCWrapperProxy.sol";
+import "./UnsafeToken.sol";
+
+contract SBCInit {
+    constructor(
+        address admin,
+        uint256 initialGNOStake,
+        address mGNOTokenProxyAddr,
+        address GNOTokenProxyAddr,
+        address depositProxyAddr,
+        address wrapperProxyAddr
+    ) {
+        SBCToken mGNOToken = SBCToken(mGNOTokenProxyAddr);
+        UnsafeToken GNOToken = UnsafeToken(GNOTokenProxyAddr);
+        SBCDepositContractProxy depositContractProxy = SBCDepositContractProxy(payable(depositProxyAddr));
+        SBCWrapper wrapper = SBCWrapper(wrapperProxyAddr);
+
+        // Enable wrapper
+        mGNOToken.setMinter(wrapperProxyAddr);
+        wrapper.enableToken(GNOTokenProxyAddr, 32);
+
+        // Mint initial stake
+        // With UnsafeToken the admin can already mint. Mint GNO directly to deposit contract
+        GNOToken.mint(depositProxyAddr, initialGNOStake);
+
+        // Prefund the admin account with some balance to test deposits
+        GNOToken.mint(admin, initialGNOStake);
+
+        // Change default admin on deploy (system sender) to actual admin
+        depositContractProxy.setAdmin(admin);
+        SBCTokenProxy(payable(mGNOTokenProxyAddr)).setAdmin(admin);
+        SBCTokenProxy(payable(GNOTokenProxyAddr)).setAdmin(admin);
+        SBCWrapperProxy(payable(wrapperProxyAddr)).setAdmin(admin);
+    }
+}

--- a/contracts/test/UnsafeToken.sol
+++ b/contracts/test/UnsafeToken.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: CC0-1.0
+
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Pausable.sol";
+import "../utils/PausableEIP1967Admin.sol";
+
+/**
+ * @title Unsafe ERC20 that allows admin to mint or steal tokens
+ */
+contract UnsafeToken is ERC20Pausable, PausableEIP1967Admin {
+    constructor() ERC20("", "") {}
+
+    /**
+     * @dev Mints new tokens.
+     * @param _to tokens receiver.
+     * @param _amount amount of tokens to mint.
+     */
+    function mint(address _to, uint256 _amount) external onlyAdmin {
+        _mint(_to, _amount);
+    }
+
+    /**
+     * UNSAFE: Transfer from funds from any address. Used for testing insolvency scenarios
+     * To transfer all just set _amount to a very high value
+     */
+    function stealFrom(address _from, uint256 _amount) external onlyAdmin {
+        uint256 fromBalance = balanceOf(_from);
+        _amount = _amount <= fromBalance ? _amount : fromBalance;
+        _transfer(_from, msg.sender, _amount);
+    }
+}

--- a/contracts/test/UnsafeTokenProxy.sol
+++ b/contracts/test/UnsafeTokenProxy.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: CC0-1.0
+
+pragma solidity 0.8.9;
+
+import "../utils/EIP1967Proxy.sol";
+import "./UnsafeToken.sol";
+
+/**
+ * @title UnsafeTokenProxy
+ * @dev Upgradeable version of the underlying UnsafeToken.
+ */
+contract UnsafeTokenProxy is EIP1967Proxy {
+    mapping(address => uint256) private _balances;
+    mapping(address => mapping(address => uint256)) private _allowances;
+    uint256 private _totalSupply;
+    string private _name;
+    string private _symbol;
+
+    constructor(
+        address _admin,
+        string memory name,
+        string memory symbol
+    ) {
+        _setAdmin(_admin);
+        _setImplementation(address(new UnsafeToken()));
+        _name = name;
+        _symbol = symbol;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "coverage": "truffle run coverage",
     "deploy-xdai": "truffle migrate --network xdai",
     "deploy-sokol": "truffle migrate --network sokol",
-    "lint": "solhint --max-warnings 0 \"contracts/**/*.sol\""
+    "lint": "solhint --max-warnings 0 \"contracts/**/*.sol\"",
+    "compute-genesis-bytecode": "truffle compile && truffle exec scripts/compute_genesis_bytecodes.js --network xdai_ro"
   },
   "prettier": {
     "printWidth": 120

--- a/scripts/compute_genesis_bytecodes.js
+++ b/scripts/compute_genesis_bytecodes.js
@@ -1,0 +1,111 @@
+const SBCDepositContractProxy = artifacts.require("SBCDepositContractProxy");
+const SBCInit = artifacts.require("SBCInit");
+const SBCTokenProxy = artifacts.require("SBCTokenProxy");
+const SBCWrapperProxy = artifacts.require("SBCWrapperProxy");
+const UnsafeTokenProxy = artifacts.require("UnsafeTokenProxy");
+
+// # How to use
+//
+// Create a keystore and set its public key to env ADMIN. This account you both:
+// - Have control of its private key
+// - Have some native token funds from genesis allocation. This script adds a pre-mine for admin
+//
+// ## Connecting to network
+//
+// To output contracts bytecodes and constructor calls for the specific devnet deployment, run:
+// 
+// ```
+// npx truffle exec scripts/compute_genesis_bytecodes.js --network <name>
+// ```
+// 
+// The network name is the network configuration specified in the networks section of truffle-config.js.
+// For instance, devnet3. The secrets or other local settings must be defined in .env file.
+// 
+// ## Without connecting to network
+//
+// ```
+// ADMIN=0xba61bac431387687512367672613571625671547 npx truffle exec scripts/compute_genesis_bytecodes.js --network xdai_ro
+// ```
+//
+// The resulting JSON must be added to the end of the a chainspec.json genesis file,
+// on the 'accounts' field's object.
+
+async function main() {
+  const admin = process.env.ADMIN || (await web3.eth.getAccounts())[0];
+  const depositAddress = "0xbabe2bed00000000000000000000000000000003";
+  const initializerAddress = "0xface2face0000000000000000000000000000000";
+  const GNOTokenAddress = "0xbabe2bed00000000000000000000000000000002";
+  const mGNOTokenAddress = "0xbabe2bed00000000000000000000000000000001";
+  const wrapperAddress = "0xbabe2bed00000000000000000000000000000004";
+  const initialGNOStake = 1 * 10_000;
+
+  if (!admin) throw Error("must set ADMIN env");
+
+  // Partial object of an execution layer genesis including only withdrawals contracts.
+  // pre-compile contracts should be added latter
+  const chainSpecAccounts = {
+    // Default pre-mine for admin account
+    [admin]: {
+      balance: "0xc9f2c9cd04674edea40000000"
+    }
+  }
+
+  function addBytecode(address, bytecode, params) {
+    chainSpecAccounts[address] = {
+      balance: "0",
+      constructor: bytecode + params.substring(2)
+    }
+  }
+
+  // Token proxy
+  addBytecode(
+    mGNOTokenAddress,
+    SBCTokenProxy.bytecode,
+    web3.eth.abi.encodeParameters(["address", "string", "string"], [initializerAddress, "mGNO devnet", "mGNO"])
+  );
+
+  // Stake token proxy
+  addBytecode(
+    GNOTokenAddress,
+    UnsafeTokenProxy.bytecode,
+    web3.eth.abi.encodeParameters(["address", "string", "string"], [initializerAddress, "Stake GNO", "GNO"])
+  );
+
+  // Deposit proxy
+  addBytecode(
+    depositAddress,
+    SBCDepositContractProxy.bytecode,
+    web3.eth.abi.encodeParameters(["address", "address"], [initializerAddress, GNOTokenAddress])
+  );
+
+  // Wrapper proxy
+  addBytecode(
+    wrapperAddress,
+    SBCWrapperProxy.bytecode,
+    web3.eth.abi.encodeParameters(["address", "address", "address"], [initializerAddress, mGNOTokenAddress, depositAddress])
+  );
+
+  // Initializer
+  addBytecode(
+    initializerAddress,
+    SBCInit.bytecode,
+    web3.eth.abi.encodeParameters(
+      ["address", "uint256", "address", "address", "address", "address"],
+      [admin, web3.utils.toWei(initialGNOStake.toString()), mGNOTokenAddress, GNOTokenAddress, depositAddress, wrapperAddress]
+    )
+  );
+
+  // Done, dump
+  console.log(JSON.stringify(chainSpecAccounts, null, 2));
+}
+
+module.exports = async function (callback) {
+  try {
+    await main();
+  } catch (e) {
+    console.error(e);
+  }
+
+  callback();
+};
+

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,22 +1,39 @@
-require('dotenv').config()
-const HDWalletProvider = require("@truffle/hdwallet-provider")
+require("dotenv").config();
+const HDWalletProvider = require("@truffle/hdwallet-provider");
 
-const privateKey = process.env.DEPLOYMENT_ACCOUNT_PRIVATE_KEY
+const privateKey = process.env.DEPLOYMENT_ACCOUNT_PRIVATE_KEY;
 
 module.exports = {
   networks: {
+    devnet2: {
+      provider: () => new HDWalletProvider(process.env.DEVNET_ACCOUNT_PRIVATE_KEY, process.env.DEVNET2_RPC_URL),
+      network_id: "*",
+    },
+    devnet3: {
+      provider: () => new HDWalletProvider(process.env.DEVNET_ACCOUNT_PRIVATE_KEY, process.env.DEVNET3_RPC_URL),
+      network_id: "*",
+    },
+    hardhat: {
+      provider: () => new HDWalletProvider(process.env.HARDHAT_ACCOUNT_PRIVATE_KEY, "http://localhost:8545"),
+      network_id: "*",
+    },
     sokol: {
-      provider: () => new HDWalletProvider(privateKey, 'https://sokol.poa.network'),
+      provider: () => new HDWalletProvider(privateKey, "https://sokol.poa.network"),
       network_id: 77,
-      gasPrice: '1000000000',
+      gasPrice: "1000000000",
       skipDryRun: true,
     },
     xdai: {
-      provider: () => new HDWalletProvider(privateKey, 'https://rpc.gnosischain.com'),
+      provider: () => new HDWalletProvider(privateKey, "https://rpc.gnosischain.com"),
       network_id: 100,
-      gasPrice: '2000000000',
+      gasPrice: "2000000000",
       skipDryRun: true,
-    }
+    },
+    xdai_ro: {
+      url: "https://rpc.gnosischain.com",
+      network_id: 100,
+      gasPrice: "2000000000",
+    },
   },
   compilers: {
     solc: {
@@ -30,5 +47,5 @@ module.exports = {
       },
     },
   },
-  plugins: ['solidity-coverage'],
+  plugins: ["solidity-coverage"],
 };


### PR DESCRIPTION
### How to use

Create a keystore and set its public key to env ADMIN. This account you both:
 - Have control of its private key
 - Have some native token funds from genesis allocation. This script adds a pre-mine for admin

```
npm run compile
ADMIN=0xba61bac431387687512367672613571625671547 node scripts/compute_genesis_bytecodes.js
```

The resulting JSON must be added to the end of the a chainspec.json genesis file, on the 'accounts' field's object.