### PR TITLE
perf: cache storage and calldata

### DIFF
--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -309,7 +309,7 @@ contract SBCDepositContract is
         uint256 amountToProceed = cachedFailedWithdrawalRecord.amount;
         if (_msgSender() == cachedFailedWithdrawalRecord.receiver) {
             if (_amountToProceed != 0) {
-                require(_amountToProceed <= cachedFailedWithdrawalRecord.amount, "Invalid amount of tokens");
+                require(_amountToProceed <= amountToProceed, "Invalid amount of tokens");
                 amountToProceed = _amountToProceed;
             }
         }
@@ -319,7 +319,7 @@ contract SBCDepositContract is
         if (amountToProceed == cachedFailedWithdrawalRecord.amount) {
             failedWithdrawalRecord.processed = true;
         } else {
-            failedWithdrawalRecord.amount -= amountToProceed;
+            failedWithdrawalRecord.amount = cachedFailedWithdrawalRecord.amount - amountToProceed;
         }
         emit FailedWithdrawalProcessed(_failedWithdrawalId, amountToProceed, cachedFailedWithdrawalRecord.receiver);
     }


### PR DESCRIPTION
From the preliminary audit:
- the `processFailedWithdrawal()` function reads `FailedWithdrawalRecord` values from storage multiple times, consider using a local variable instead.
- the `processFailedWithdrawalsFromPointer()` function reads `numberOfFailedWithdrawals` value from storage multiple times, consider using a local variable instead.
- the `processFailedWithdrawalsFromPointer()` function reads `failedWithdrawalsPointer` value from storage multiple times, consider using a local variable instead.
- the `processFailedWithdrawalsFromPointer()` function reads `FailedWithdrawalRecord` values from storage multiple times, consider reading it into memory once instead.
- the `executeSystemWithdrawals()` function reads `_addresses[i]` from calldata multiple times, it would be cheaper to store it in a local variable.
- the `executeSystemWithdrawals()` function reads `numberOfFailedWithdrawals` value from storage multiple times, consider using a local variable instead.