### PR TITLE
Track withdraw index in deposit contract

### DIFF
--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -391,6 +391,17 @@ contract SBCDepositContract is
     }
 
     /**
+     * @dev Check if a block's withdrawal has been fully processed or not
+     * @param _withdrawalIndex EIP-4895 withdrawal.index property
+     */
+    function isWithdrawalProcessed(uint64 _withdrawalIndex) external view returns (bool) {
+        require(_withdrawalIndex < nextWithdrawalIndex, "withdrawal_index out-of-bounds");
+        // If there are no withdrawals failedWithdrawalByIndex returns zero, failedWithdrawals empty struct
+        // such that amount is zero and this function returns true
+        return failedWithdrawals[failedWithdrawalByIndex[_withdrawalIndex]].amount == 0;
+    }
+
+    /**
      * @dev Allows to unwrap the mGNO in this contract to GNO
      * Only admin can call this method.
      * @param _unwrapper address of the mGNO token unwrapper

--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -271,9 +271,11 @@ contract SBCDepositContract is
     struct FailedWithdrawalRecord {
         uint256 amount;
         address receiver;
+        uint64 withdrawalIndex;
     }
     mapping(uint256 => FailedWithdrawalRecord) public failedWithdrawals;
     uint256 public numberOfFailedWithdrawals;
+    uint64 public nextWithdrawalIndex;
 
     /**
      * @dev Function to be used to process a failed withdrawal (possibly partially).
@@ -374,11 +376,15 @@ contract SBCDepositContract is
             } else {
                 failedWithdrawals[numberOfFailedWithdrawals] = FailedWithdrawalRecord({
                     amount: amount,
-                    receiver: _addresses[i]
+                    receiver: _addresses[i],
+                    withdrawalIndex: nextWithdrawalIndex
                 });
                 emit WithdrawalFailed(numberOfFailedWithdrawals, amount, _addresses[i]);
                 ++numberOfFailedWithdrawals;
             }
+
+            // First withdrawal is index 0
+            nextWithdrawalIndex++;
         }
     }
 

--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -274,6 +274,7 @@ contract SBCDepositContract is
         uint64 withdrawalIndex;
     }
     mapping(uint256 => FailedWithdrawalRecord) public failedWithdrawals;
+    mapping(uint64 => uint256) public failedWithdrawalByIndex;
     uint256 public numberOfFailedWithdrawals;
     uint64 public nextWithdrawalIndex;
 
@@ -379,6 +380,7 @@ contract SBCDepositContract is
                     receiver: _addresses[i],
                     withdrawalIndex: nextWithdrawalIndex
                 });
+                failedWithdrawalByIndex[nextWithdrawalIndex] = numberOfFailedWithdrawals;
                 emit WithdrawalFailed(numberOfFailedWithdrawals, amount, _addresses[i]);
                 ++numberOfFailedWithdrawals;
             }


### PR DESCRIPTION
Deposit contract must expose a way to link a `FailedWithdrawalRecord` to a specific withdraw in a block. Otherwise in case of failed withdrawals it's not possible to deterministically assert a block's withdrawal status. This can be an issue for block explorers and other user facing tooling.

For explorers, to know if a withdrawal in a block has been executed, do:
```rs
fn is_withdrawal_processed(withdrawal: Withdrawal) {
  return deposit_contract.isWithdrawalProcessed(withdrawal.index);
]
```

The Withdrawal data structure defined in https://eips.ethereum.org/EIPS/eip-4895 includes an `index` property which is
- a monotonically increasing index, starting from 0, as a uint64 value that increments by 1 per withdrawal to uniquely identify each withdrawal

Instead of changing the function signature on the execution client to include this data, the deposit contract tracks `nextWithdrawalIndex` internally. As the system transaction is **guaranteed** to be executed on every block, the deposit contract can derive the indexes itself.
