### PR TITLE
Set chiado deprecated slots to zero

### DIFF
--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -52,7 +52,10 @@ contract SBCDepositContract is
     // SBCDepositContractOld  │       numberOfFailedWithdrawals        │      69      │                             t_uint256                             │      32       │
     // SBCDepositContractOld  │          nextWithdrawalIndex           │      70      │                             t_uint64                              │       8       │
     // SBCDepositContractOld  │        failedWithdrawalsPointer        │      71      │                             t_uint256                             │      32       |
-    uint256[4] private _deprecated_slots_gap;
+    mapping(uint64 => uint256) public _deprecated_map_up_to_nextWithdrawalIndex;
+    uint256 public _deprecated_slot_69;
+    uint64 public _deprecated_slot_70_nextWithdrawalIndex;
+    uint256 private _deprecated_slot_71;
 
     constructor(address _token) {
         stake_token = IERC20(_token);
@@ -313,10 +316,23 @@ contract SBCDepositContract is
     /**
      * @dev See `_deprecated_slots_gap` comment for rationale
      */
-    function setSlotGapToZero() external onlyAdmin {
-        // set storage slots 69,70,71 back to zero 
-        _deprecated_slots_gap[1] = 0;
-        _deprecated_slots_gap[2] = 0;
-        _deprecated_slots_gap[3] = 0;
+    function setSlotGapToZero(uint64 n) external onlyAdmin {
+        uint64 _nextWithdrawalIndex = _deprecated_slot_70_nextWithdrawalIndex;
+
+        for (uint64 i = 0; i < n; ++i) {
+            _deprecated_map_up_to_nextWithdrawalIndex[_nextWithdrawalIndex - i] = 0;
+
+            if (_nextWithdrawalIndex - i == 0) {
+                // entire map cleared
+                // set storage slots 69,70,71 back to zero 
+                _deprecated_slot_69 = 0;
+                _deprecated_slot_70_nextWithdrawalIndex = 0;
+                _deprecated_slot_71 = 0;
+                return;
+            }
+        }
+
+        // map not cleared yet, store progress
+        _deprecated_slot_70_nextWithdrawalIndex = _nextWithdrawalIndex - n;
     }
 }

--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -46,7 +46,7 @@ contract SBCDepositContract is
     // Chiado network deployed for the shapella the contract at commit https://github.com/gnosischain/deposit-contract/commit/13e155500b626612844e3d0fccc11b02b11ea785
     // This contract version was latter replaced with the contract at commit https://github.com/gnosischain/deposit-contract/pull/45/commits/8fe75d23497d720b12af9e75790a616dfb64ca6b
     // The latter version leaves some storage slots orphan, which may cause problems in future updates
-    // This variable is added once to set storage slots 69,70,71 back to zero 
+    // This variables is added once to set storage slots 69,70,71 and map(68) values back to zero
     // SBCDepositContract     │           withdrawableAmount           │      67      │                  t_mapping(t_address,t_uint256)                   │      32       │
     // SBCDepositContractOld  │ failedWithdrawalIndexByWithdrawalIndex │      68      │                   t_mapping(t_uint64,t_uint256)                   │      32       │
     // SBCDepositContractOld  │       numberOfFailedWithdrawals        │      69      │                             t_uint256                             │      32       │

--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -314,7 +314,7 @@ contract SBCDepositContract is
     }
 
     /**
-     * @dev See `_deprecated_slots_gap` comment for rationale
+     * @dev See `_deprecated_slot_X` variables comment for rationale
      */
     function setSlotGapToZero(uint64 n) external onlyAdmin {
         uint64 _nextWithdrawalIndex = _deprecated_slot_70_nextWithdrawalIndex;

--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -42,6 +42,18 @@ contract SBCDepositContract is
     address private constant SYSTEM_WITHDRAWAL_EXECUTOR = 0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE;
     mapping(address => uint256) public withdrawableAmount;
 
+    // failedWithdrawalIndexByWithdrawalIndex
+    // Chiado network deployed for the shapella the contract at commit https://github.com/gnosischain/deposit-contract/commit/13e155500b626612844e3d0fccc11b02b11ea785
+    // This contract version was latter replaced with the contract at commit https://github.com/gnosischain/deposit-contract/pull/45/commits/8fe75d23497d720b12af9e75790a616dfb64ca6b
+    // The latter version leaves some storage slots orphan, which may cause problems in future updates
+    // This variable is added once to set storage slots 69,70,71 back to zero 
+    // SBCDepositContract     │           withdrawableAmount           │      67      │                  t_mapping(t_address,t_uint256)                   │      32       │
+    // SBCDepositContractOld  │ failedWithdrawalIndexByWithdrawalIndex │      68      │                   t_mapping(t_uint64,t_uint256)                   │      32       │
+    // SBCDepositContractOld  │       numberOfFailedWithdrawals        │      69      │                             t_uint256                             │      32       │
+    // SBCDepositContractOld  │          nextWithdrawalIndex           │      70      │                             t_uint64                              │       8       │
+    // SBCDepositContractOld  │        failedWithdrawalsPointer        │      71      │                             t_uint256                             │      32       |
+    uint256[4] private _deprecated_slots_gap;
+
     constructor(address _token) {
         stake_token = IERC20(_token);
     }
@@ -296,5 +308,15 @@ contract SBCDepositContract is
      */
     function unwrapTokens(IUnwrapper _unwrapper, IERC20 _token) external onlyAdmin {
         _unwrapper.unwrap(address(stake_token), _token.balanceOf(address(this)));
+    }
+
+    /**
+     * @dev See `_deprecated_slots_gap` comment for rationale
+     */
+    function setSlotGapToZero() external onlyAdmin {
+        // set storage slots 69,70,71 back to zero 
+        _deprecated_slots_gap[1] = 0;
+        _deprecated_slots_gap[2] = 0;
+        _deprecated_slots_gap[3] = 0;
     }
 }

--- a/migrations/2_upgrade_chiado_shapella.js
+++ b/migrations/2_upgrade_chiado_shapella.js
@@ -1,0 +1,21 @@
+require('dotenv').config()
+
+const SBCDepositContractProxy = artifacts.require('SBCDepositContractProxy')
+const SBCDepositContract = artifacts.require('SBCDepositContract')
+
+module.exports = async function (deployer, network, accounts) {
+  if (network !== 'test' && network !== 'soliditycoverage') {
+    const gnoTokenProxyAddress = process.env.GNO_TOKEN_PROXY_ADDRESS
+    const depositContractProxyAddress = process.env.DEPOSIT_CONTRACT_PROXY_ADDRESS
+
+    // deploy deposit contract implementation
+    // ```
+    // constructor(address _token)
+    // ```
+    await deployer.deploy(SBCDepositContract, gnoTokenProxyAddress)
+    const depositContractImplementation = await SBCDepositContract.deployed()
+    // upgrade deposit with the correct unwrapper address
+    const depositContractProxy = await SBCDepositContractProxy.at(depositContractProxyAddress)
+    await depositContractProxy.upgradeTo(depositContractImplementation.address)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "deploy-xdai": "truffle migrate --network xdai",
     "deploy-sokol": "truffle migrate --network sokol",
     "lint": "solhint --max-warnings 0 \"contracts/**/*.sol\"",
-    "compute-genesis-bytecode": "truffle compile && truffle exec scripts/compute_genesis_bytecodes.js --network xdai_ro"
+    "compute-genesis-bytecode": "truffle compile && truffle exec scripts/compute_genesis_bytecodes.js --network xdai_ro",
+    "zeroout-chiado": "truffle exec scripts/zeroout_chiado_deposit.js --network chiado"
   },
   "prettier": {
     "printWidth": 120

--- a/scripts/zeroout_chiado_deposit.js
+++ b/scripts/zeroout_chiado_deposit.js
@@ -1,0 +1,92 @@
+
+const SBCDepositContract = artifacts.require("SBCDepositContract");
+
+require('dotenv').config()
+
+const GNO_TOKEN_PROXY_ADDRESS = "0x19C653Da7c37c66208fbfbE8908A5051B57b4C70"
+const DEPOSIT_CONTRACT_PROXY_ADDRESS = "0xb97036A26259B7147018913bD58a774cf91acf25"
+
+async function main() {
+  const admin = (await web3.eth.getAccounts())[0];
+  console.log(`connected account ${admin} - must be admin`);
+
+  const MAX_CONCURRENT_TX = 10
+  const MAX_GAS_PER_BLOCK = 30e6
+  const MAX_GAS_PER_TRANSACTION = MAX_GAS_PER_BLOCK * 0.98
+  const APROX_GAS_COST_PER_N = 5_000
+  const GAS_PRICE = 6.1e9
+  const N = 5000
+
+  const depositContract = new web3.eth.Contract(SBCDepositContract.abi, DEPOSIT_CONTRACT_PROXY_ADDRESS)
+  const transactionData = depositContract.methods.setSlotGapToZero(N).encodeABI()
+
+  
+
+  // Sent multiple transactions at once
+  // const pendingTransactions = 
+
+  let completed = false
+  const pendingNonces = new Set()
+
+  async function sendTx() {
+    if (completed) return
+
+    try {
+      let nonce = await web3.eth.getTransactionCount(admin, 'pending')
+
+      // Find un-used nonce
+      while (pendingNonces.has(nonce)) {
+        nonce++
+      }
+      pendingNonces.add(nonce)
+
+      const receipt = await new Promise((resolve, reject) => {
+        web3.eth.sendTransaction({
+        from: admin,
+        to: DEPOSIT_CONTRACT_PROXY_ADDRESS,
+        gasLimit: MAX_GAS_PER_TRANSACTION,
+        gasPrice: GAS_PRICE,
+        data: transactionData,
+        nonce
+      })
+        .on('transactionHash', (hash) => console.log(`tx ${hash} nonce ${nonce} submitted`))
+        .on('receipt', (receipt) => resolve(receipt))
+        .on('error', e => reject(e))
+      })
+      console.log(`tx ${receipt.transactionHash} nonce ${nonce} included in block ${receipt.blockNumber}`)
+    } catch (e) {
+      console.error("tx error", e)
+    }
+    sendTx()
+  }
+
+  for (let i = 0; i < MAX_CONCURRENT_TX; i++) {
+    sendTx()
+  }
+
+  // Background task to pull nextWithdrawalIndex
+  await new Promise((resolve) => {
+    setInterval(() => {
+      depositContract.methods._deprecated_slot_70_nextWithdrawalIndex().call()
+        .then(nextWithdrawalIndex => {
+          console.log(Date.now(), nextWithdrawalIndex)
+          if (nextWithdrawalIndex == 0) {
+            completed = true
+            resolve()
+          }
+        })
+        .catch(e => console.error("nextWithdrawalIndex error", e))
+    }, 5 * 1000)
+  })
+  
+}
+
+module.exports = async function (callback) {
+  try {
+    await main();
+  } catch (e) {
+    console.error(e);
+  }
+
+  callback();
+};

--- a/scripts/zeroout_chiado_deposit.js
+++ b/scripts/zeroout_chiado_deposit.js
@@ -34,7 +34,9 @@ async function main() {
   }
 }
 
-main().catch(e => {
-  console.error(e)
-  process.exit(1);
-})
+
+module.exports = async function (callback) {
+  await main();
+  callback();
+};
+

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -34,6 +34,12 @@ module.exports = {
       network_id: 100,
       gasPrice: "2000000000",
     },
+    chiado: {
+      provider: () => new HDWalletProvider(privateKey, "https://rpc.chiadochain.net"),
+      network_id: 10200,
+      gasPrice: "1000000000",
+      skipDryRun: true,
+    },
   },
   compilers: {
     solc: {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -35,10 +35,15 @@ module.exports = {
       gasPrice: "2000000000",
     },
     chiado: {
-      provider: () => new HDWalletProvider(privateKey, "https://rpc.chiadochain.net"),
+      provider: () => new HDWalletProvider(process.env.CHIADO_ADMIN_PRIVATEKEY, "https://rpc.chiadochain.net"),
       network_id: 10200,
       gasPrice: "1000000000",
       skipDryRun: true,
+    },
+    chiado_ro: {
+      url: "https://rpc.chiadochain.net",
+      network_id: 10200,
+      gasPrice: "1000000000",
     },
   },
   compilers: {


### PR DESCRIPTION
 Chiado network deployed for the shapella the contract at commit https://github.com/gnosischain/deposit-contract/commit/13e155500b626612844e3d0fccc11b02b11ea785. This contract version was latter replaced with the contract at commit https://github.com/gnosischain/deposit-contract/pull/45/commits/8fe75d23497d720b12af9e75790a616dfb64ca6b. The latter version leaves some storage slots orphan, which may cause problems in future updates.


This PR introduces a method to set the gap slots to zero. `_deprecated_slots_gap` variable is added once to set storage slots 69,70,71 back to zero 

   
    SBCDepositContract     │           withdrawableAmount           │      67      │                  t_mapping(t_address,t_uint256)                   │      32       │
    SBCDepositContractOld  │ failedWithdrawalIndexByWithdrawalIndex │      68      │                   t_mapping(t_uint64,t_uint256)                   │      32       │
    SBCDepositContractOld  │       numberOfFailedWithdrawals        │      69      │                             t_uint256                             │      32       │
    SBCDepositContractOld  │          nextWithdrawalIndex           │      70      │                             t_uint64                              │       8       │
    SBCDepositContractOld  │        failedWithdrawalsPointer        │      71      │                             t_uint256                             │      32       |


**Deployment plan**
- Upgrade contract to this implementation
- Call `setSlotGapToZero`
- Forget about it

----


- Replaces https://github.com/gnosischain/deposit-contract/pull/46 and https://github.com/gnosischain/deposit-contract/pull/47