### PR TITLE
chore: fix system tx inputs

### DIFF
--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -256,7 +256,6 @@ contract SBCDepositContract is
     }
 
     /**
-     * @custom:deprecated
      * @dev Function to be used only in the system transaction.
      * Call to this function will revert only in case:
      *     - the caller is not `SYSTEM_WITHDRAWAL_EXECUTOR` or `_admin()`;
@@ -265,6 +264,8 @@ contract SBCDepositContract is
      * NOTE: This function signature is hardcoded in the Gnosis execution layer clients. Changing this signature without updating the
      * clients will cause block verification of any post-shangai block to fail. The function signature cannonical spec is here
      * https://github.com/gnosischain/specs/blob/master/execution/withdrawals.md
+     * Note: chiado network requires this signature to sync post-shapella blocks. This function signature can only be deprecated after
+     * deprecating chiado network of full sync up to a pre-specified block.
      * @param _deprecatedUnused Previously `maxFailedWithdrawalsToProcess` currently deprecated and ignored
      * @param _amounts Array of amounts to be withdrawn.
      * @param _addresses Array of addresses that should receive the corresponding amount of tokens.
@@ -288,17 +289,9 @@ contract SBCDepositContract is
     }
 
     /**
-     * @dev Function to be used only in the system transaction.
-     * Call to this function will revert only in case:
-     *     - the caller is not `SYSTEM_WITHDRAWAL_EXECUTOR` or `_admin()`;
-     *     - the length of `_amounts` array is not equal to the length of `_addresses` array;
-     * Call to this function doesn't transmit flow control to any untrusted contract, nor does any operation of unbounded gas usage.
-     * NOTE: This function signature is not the cannonical spec'ed signature as per specs of June 2023. However it is added before use
-     * to allow syncing of olds blocks if we choose to drop the first deprecated argument in the future. 
-     * NOTE: The chiado network features a range of blocks that require the signature `executeSystemWithdrawals(uint256,uint64[],address[])`.
-     * Fully deprecating support for the above signature will not disrupt Gnosis network but will disrupt Chiado network.
-     * @param _amounts Array of amounts to be withdrawn.
-     * @param _addresses Array of addresses that should receive the corresponding amount of tokens.
+     * @dev Forwards compatible signature for `executeSystemWithdrawals` to support its future deprecation
+     * Clients must support and use the signature specified in the spec at:
+     * https://github.com/gnosischain/specs/blob/master/execution/withdrawals.md
      */
     function executeSystemWithdrawals(uint64[] calldata _amounts, address[] calldata _addresses) external {
         executeSystemWithdrawals(0, _amounts, _addresses);

--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -293,9 +293,10 @@ contract SBCDepositContract is
      *     - the caller is not `SYSTEM_WITHDRAWAL_EXECUTOR` or `_admin()`;
      *     - the length of `_amounts` array is not equal to the length of `_addresses` array;
      * Call to this function doesn't transmit flow control to any untrusted contract, nor does any operation of unbounded gas usage.
-     * NOTE: This function signature is hardcoded in the Gnosis execution layer clients. Changing this signature without updating the
-     * clients will cause block verification of any post-shangai block to fail. The function signature cannonical spec is here
-     * https://github.com/gnosischain/specs/blob/master/execution/withdrawals.md
+     * NOTE: This function signature is not the cannonical spec'ed signature as per specs of June 2023. However it is added before use
+     * to allow syncing of olds blocks if we choose to drop the first deprecated argument in the future. 
+     * NOTE: The chiado network features a range of blocks that require the signature `executeSystemWithdrawals(uint256,uint64[],address[])`.
+     * Fully deprecating support for the above signature will not disrupt Gnosis network but will disrupt Chiado network.
      * @param _amounts Array of amounts to be withdrawn.
      * @param _addresses Array of addresses that should receive the corresponding amount of tokens.
      */

--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -273,7 +273,7 @@ contract SBCDepositContract is
         uint256 _deprecatedUnused,
         uint64[] calldata _amounts,
         address[] calldata _addresses
-    ) external {
+    ) public {
         require(
             _msgSender() == SYSTEM_WITHDRAWAL_EXECUTOR || _msgSender() == _admin(),
             "This function should be called only by SYSTEM_WITHDRAWAL_EXECUTOR or _admin()"

--- a/contracts/SBCDepositContract.sol
+++ b/contracts/SBCDepositContract.sol
@@ -256,6 +256,7 @@ contract SBCDepositContract is
     }
 
     /**
+     * @custom:deprecated
      * @dev Function to be used only in the system transaction.
      * Call to this function will revert only in case:
      *     - the caller is not `SYSTEM_WITHDRAWAL_EXECUTOR` or `_admin()`;
@@ -284,6 +285,22 @@ contract SBCDepositContract is
             uint256 amount = (uint256(_amounts[i]) * 1 gwei) / 32;
             withdrawableAmount[_addresses[i]] += amount;
         }
+    }
+
+    /**
+     * @dev Function to be used only in the system transaction.
+     * Call to this function will revert only in case:
+     *     - the caller is not `SYSTEM_WITHDRAWAL_EXECUTOR` or `_admin()`;
+     *     - the length of `_amounts` array is not equal to the length of `_addresses` array;
+     * Call to this function doesn't transmit flow control to any untrusted contract, nor does any operation of unbounded gas usage.
+     * NOTE: This function signature is hardcoded in the Gnosis execution layer clients. Changing this signature without updating the
+     * clients will cause block verification of any post-shangai block to fail. The function signature cannonical spec is here
+     * https://github.com/gnosischain/specs/blob/master/execution/withdrawals.md
+     * @param _amounts Array of amounts to be withdrawn.
+     * @param _addresses Array of addresses that should receive the corresponding amount of tokens.
+     */
+    function executeSystemWithdrawals(uint64[] calldata _amounts, address[] calldata _addresses) external {
+        executeSystemWithdrawals(0, _amounts, _addresses);
     }
 
     /**

--- a/test/deposit.js
+++ b/test/deposit.js
@@ -205,9 +205,9 @@ contract('SBCDepositContractProxy', (accounts) => {
     const amounts = ['0x0000000000000000', '0x0000000000000000']
     const elongatedAmounts = ['0x0000000000000000', '0x0000000000000000', '0x0000000000000000']
     const addresses = [accounts[0], accounts[0]]
-    await contract.executeSystemWithdrawals(10, amounts, addresses, { from: accounts[1] }).should.be.rejected
-    await contract.executeSystemWithdrawals(10, elongatedAmounts, addresses, { from: accounts[0] }).should.be.rejected
-    await contract.executeSystemWithdrawals(10, amounts, addresses, { from: accounts[0] })
+    await contract.executeSystemWithdrawals(amounts, addresses, { from: accounts[1] }).should.be.rejected
+    await contract.executeSystemWithdrawals(elongatedAmounts, addresses, { from: accounts[0] }).should.be.rejected
+    await contract.executeSystemWithdrawals(amounts, addresses, { from: accounts[0] })
   })
 
   it('should correctly withdraw GNO for one address', async () => {
@@ -217,7 +217,7 @@ contract('SBCDepositContractProxy', (accounts) => {
     // simple withdrawal
     await stake.transfer(contract.address, depositAmount)
 
-    await contract.executeSystemWithdrawals(0, amounts, addresses)
+    await contract.executeSystemWithdrawals(amounts, addresses)
     const claimableGNO = (await contract.withdrawableAmount(accounts[1])).toString()
     expect(claimableGNO).to.be.equal(depositAmount)
 
@@ -234,7 +234,7 @@ contract('SBCDepositContractProxy', (accounts) => {
     // simple withdrawal
     await stake.transfer(contract.address, web3.utils.toWei(String(addressCount)))
 
-    await contract.executeSystemWithdrawals(0, amounts, addresses)
+    await contract.executeSystemWithdrawals(amounts, addresses)
     for (let i = 0; i < addressCount; i++) {
       const claimableGNO = (await contract.withdrawableAmount(addresses[i])).toString()
       expect(claimableGNO).to.be.equal(depositAmount)
@@ -254,7 +254,7 @@ contract('SBCDepositContractProxy', (accounts) => {
     // simple withdrawal
     await token.transfer(contract.address, thirtyTwoEther)
 
-    await contract.executeSystemWithdrawals(0, amounts, addresses)
+    await contract.executeSystemWithdrawals(amounts, addresses)
     const mGNOBalanceAfterWithdrawal = (await token.balanceOf(accounts[1])).toString()
     expect(mGNOBalanceAfterWithdrawal).to.be.equal(web3.utils.toWei('0'))
   })
@@ -266,7 +266,7 @@ contract('SBCDepositContractProxy', (accounts) => {
     // simple withdrawal
     await token.transfer(contract.address, thirtyTwoEther)
 
-    await contract.executeSystemWithdrawals(0, amounts, addresses)
+    await contract.executeSystemWithdrawals(amounts, addresses)
     const mGNOBalanceAfterFirstWithdrawal = (await token.balanceOf(zeroAddress)).toString()
     expect(mGNOBalanceAfterFirstWithdrawal).to.be.equal(zeroEther)
   })


### PR DESCRIPTION
This needs to be deployed before the merge gets deployed or it might prevent nodes from syncing without specific checks.

This will not work on Chiado without any specific exceptions though, so we might not want to merge this for mainnet, as it would mean that we'd either have to keep the deprecated signature anyways, or implement an override in the EL clients.